### PR TITLE
Doc: fix 'labelFormat' type in ValueAxis docs

### DIFF
--- a/src/charts/axis/valueaxis/qvalueaxis.cpp
+++ b/src/charts/axis/valueaxis/qvalueaxis.cpp
@@ -152,7 +152,7 @@ QT_CHARTS_BEGIN_NAMESPACE
   \sa QString::asprintf()
 */
 /*!
-  \qmlproperty real ValueAxis::labelFormat
+  \qmlproperty string ValueAxis::labelFormat
 
   The format string supports the following conversion specifiers, length modifiers, and flags
   provided by \c printf() in the standard C++ library: d, i, o, x, X, f, F, e, E, g, G, c.


### PR DESCRIPTION
It was incorrectly documented as being an int, when it is actually a string, as noted below and in the actual code.

Task-number: [QTBUG-62461](https://bugreports.qt.io/browse/QTBUG-62461)