### PR TITLE
 Add changes file for Qt 5.12.1

### DIFF
--- a/dist/changes-5.12.1
+++ b/dist/changes-5.12.1
@@ -1,0 +1,25 @@
+Qt 5.12.1 is a bug-fix release. It maintains both forward and backward
+compatibility (source and binary) with Qt 5.12.0.
+
+For more details, refer to the online documentation included in this
+distribution. The documentation is also available online:
+
+http://doc.qt.io/qt-5/index.html
+
+The Qt version 5.12 series is binary compatible with the 5.11.x series.
+Applications compiled for 5.11 will continue to run with 5.12.
+
+Some of the changes listed in this file include issue tracking numbers
+corresponding to tasks in the Qt Bug Tracker:
+
+https://bugreports.qt.io/
+
+Each of these identifiers can be entered in the bug tracker to obtain more
+information about a particular change.
+
+****************************************************************************
+*                                Bug Fixes                                 *
+****************************************************************************
+
+- [QTBUG-67981] Fix printing of labels for line series charts
+- [QTBUG-71013] Fix access to bar sets instantiated inside the module


### PR DESCRIPTION
+ 1bf73796a92ccd1599e5c762b73a76e545e48262 Bump version
+ e05f25fcbc8dfd7bfd71caf2499895851af4e484 Doc: Clarify the impact of a zoom to properties
+ 2b908b6324a78842b7dbd6b50da03baecd70b3fa Fix printing of labels for line series charts
+ 444aeb81f2555a37d94862ceaaa8295c5c7ddddd Add changes file for Qt 5.11.3
+ 5893fd038e4b299d235b9df9afe912c914fca2ae Remove wince check as it is not supported
+ b36af85eac67c2e92b35849b34d913ee0290cd2b Update plugins.qmltypes file
+ eb852ca7e5800577762663bc72b1f9d009cf7e51 Fix access to bar sets instantiated inside the module
+ ce310464de075a6865952c0845f93a6ea3c1ff6c Bump version

Change-Id: I29b4cbba9eeb16be727e82e3c0190b6767e7671f
Reviewed-by: Miikka Heikkinen <miikka.heikkinen@qt.io>