### PR TITLE
Series not in the chart. Please addSeries to chart first.

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,10 +1,10 @@
 dependencies:
   ../qtbase:
-    ref: 4088b27b9397fa9877bf60b8e707bba5dc51e9cb
+    ref: 6625a4744ee3b5441d7ebc07e5722df86415c809
     required: true
   ../qtdeclarative:
-    ref: 22605ed7ef39bdcfd0bb970341a495ea5b94b3dc
+    ref: 7b827225f2a5a28fea42d7e0c2113182f510ed3e
     required: false
   ../qtmultimedia:
-    ref: 5ff296c1e70d442501203f63cd8dc3e828b9101c
+    ref: 1401a8b9def73af336d060860810cf08908f8a39
     required: false


### PR DESCRIPTION
From [forum](https://forum.qt.io/topic/136200/series-not-in-the-chart-please-addseries-to-chart-first).

It is unlogical that I should
QChart *chart->addSeries(CalibSeries);
before
QScatterSeries *CalibSeries;->attachAxis(axisX);

Isn't it? And [no information](https://bugreports.qt.io/browse/QTBUG-103242) in [Qt doc](https://doc.qt.io/qt-6/qabstractseries.html#attachAxis) too...

I [suggest](https://github.com/AndreiCherniaev/qtcharts/pull/1) add information to Qt doc.
[attachAxis()](https://doc.qt.io/qt-6/qabstractseries.html#attachAxis) should be called after [addSeries()](https://doc.qt.io/qt-6/qchart.html#addSeries)